### PR TITLE
Fix: Netbox Branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(or $(NETBOX_VERSION),master)
+VERSION := $(or $(NETBOX_VERSION),main)
 VENV :=$(shell pwd -P)/netbox/venv
 PYTHON :=$(shell which python3)
 


### PR DESCRIPTION
The netbox repository does not contain a `master` branch, but a `main` branch.
Corrected branch name in Makefile, so pulling the repo works again.